### PR TITLE
refactor: remove body-parser for express parsers

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,6 @@
         "@supabase/supabase-js": "^2.38.5",
         "axios": "^1.6.0",
         "bcrypt": "^5.1.0",
-        "body-parser": "^1.20.2",
         "bullmq": "^3.13.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,6 @@
     "@supabase/supabase-js": "^2.38.5",
     "axios": "^1.6.0",
     "bcrypt": "^5.1.0",
-    "body-parser": "^1.20.2",
     "bullmq": "^3.13.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,6 @@
 import express from "express";
 import dotenv from "dotenv";
 import cors from "cors";
-import bodyParser from "body-parser";
 import { createServer } from "http";
 import { Server as SocketIO } from "socket.io";
 import prisma from "./src/config/db.js";
@@ -26,7 +25,8 @@ initRealtime(io);
 
 // Middleware
 app.use(cors());
-app.use(bodyParser.json());
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 
 // API Routes
 app.use("/api/auth", authRoutes);


### PR DESCRIPTION
## Summary
- remove body-parser dependency
- switch to Express built-in JSON and URL-encoded middleware

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c18c15b0c8327af1ed0a8f1772b24