### PR TITLE
Add Render deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,16 @@ npm run dev
 ```
 
 Ensure the backend is running and set `NEXT_PUBLIC_API_URL` to the backend URL.
+
+## Deployment on Render
+
+1. Push this repository to your Git provider.
+2. Visit the [Render Dashboard](https://dashboard.render.com) and create a new Blueprint using this repo.
+3. Render will provision services defined in `render.yaml`:
+   - `backend` Node service
+   - `frontend` Node service
+   - `aurasocial-db` PostgreSQL database
+   - `aurasocial-redis` Redis instance
+4. Populate environment variables in the Render dashboard for social API credentials and `NEXT_PUBLIC_API_URL`.
+5. Trigger a deploy to launch the full stack.
+

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,58 @@
+services:
+  - type: redis
+    name: aurasocial-redis
+    ipAllowList: []
+  - type: web
+    name: backend
+    env: node
+    rootDir: backend
+    buildCommand: npm install
+    startCommand: npm start
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: aurasocial-db
+          property: connectionString
+      - key: REDIS_HOST
+        fromService:
+          type: redis
+          name: aurasocial-redis
+          property: host
+      - key: REDIS_PORT
+        fromService:
+          type: redis
+          name: aurasocial-redis
+          property: port
+      - key: TWITTER_CLIENT_ID
+        sync: false
+      - key: TWITTER_CLIENT_SECRET
+        sync: false
+      - key: TWITTER_REDIRECT_URI
+        sync: false
+      - key: FACEBOOK_CLIENT_ID
+        sync: false
+      - key: FACEBOOK_CLIENT_SECRET
+        sync: false
+      - key: FACEBOOK_REDIRECT_URI
+        sync: false
+      - key: INSTAGRAM_CLIENT_ID
+        sync: false
+      - key: INSTAGRAM_CLIENT_SECRET
+        sync: false
+      - key: INSTAGRAM_REDIRECT_URI
+        sync: false
+  - type: web
+    name: frontend
+    env: node
+    rootDir: frontend
+    buildCommand: npm install && npm run build
+    startCommand: npm start
+    envVars:
+      - key: NEXT_PUBLIC_API_URL
+        sync: false
+databases:
+  - name: aurasocial-db
+    databaseName: aurasocial
+    user: aurasocial
+    plan: free
+    region: oregon


### PR DESCRIPTION
## Summary
- add `render.yaml` blueprint with backend, frontend, Postgres, and Redis services
- document Render deployment steps and environment variables in the README

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c1f93610883278835293ed5d90f09