### PR TITLE
Add backend test suites and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - run: npm test

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
   testEnvironment: 'node',
 };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,7 +25,8 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "nodemon": "^3.0.2",
-        "prisma": "^5.7.0"
+        "prisma": "^5.7.0",
+        "supertest": "^7.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1116,6 +1117,29 @@
         "win32"
       ]
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
@@ -1638,6 +1662,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -2212,6 +2243,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2265,6 +2306,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2423,6 +2471,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2801,6 +2860,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2890,6 +2956,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -6175,6 +6259,79 @@
       },
       "engines": {
         "node": ">=12.*"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "prisma": "prisma",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@prisma/client": "^5.7.0",
@@ -27,6 +27,8 @@
   "devDependencies": {
     "jest": "^29.7.0",
     "nodemon": "^3.0.2",
-    "prisma": "^5.7.0"
-  }
+    "prisma": "^5.7.0",
+    "supertest": "^7.1.4"
+  },
+  "type": "module"
 }

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,0 +1,14 @@
+import request from 'supertest';
+import express from 'express';
+import authRoutes from '../src/routes/auth.js';
+
+const app = express();
+app.use('/api/auth', authRoutes);
+
+describe('Authentication routes', () => {
+  it('returns health status', async () => {
+    const res = await request(app).get('/api/auth/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/backend/tests/basic.test.js
+++ b/backend/tests/basic.test.js
@@ -1,5 +1,0 @@
-const sum = (a, b) => a + b;
-
-test('adds numbers', () => {
-  expect(sum(1, 2)).toBe(3);
-});

--- a/backend/tests/posts.test.js
+++ b/backend/tests/posts.test.js
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+await jest.unstable_mockModule('../src/config/db.js', () => ({
+  default: {
+    scheduledPost: {
+      create: jest.fn().mockResolvedValue({
+        id: 1,
+        userId: 1,
+        content: 'Hello',
+        mediaUrl: null,
+        scheduledFor: new Date().toISOString(),
+        platform: 'twitter',
+      }),
+    },
+  },
+}));
+
+await jest.unstable_mockModule('../src/queue/postWorker.js', () => ({
+  postQueue: { add: jest.fn() },
+}));
+
+await jest.unstable_mockModule('../src/realtime.js', () => ({
+  emitScheduleUpdate: jest.fn(),
+}));
+
+const postsRoutes = (await import('../src/routes/posts.js')).default;
+const prisma = (await import('../src/config/db.js')).default;
+const { postQueue } = await import('../src/queue/postWorker.js');
+const { emitScheduleUpdate } = await import('../src/realtime.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/posts', postsRoutes);
+
+describe('Post scheduling', () => {
+  it('schedules a post', async () => {
+    const payload = {
+      userId: 1,
+      content: 'Hello',
+      mediaUrl: null,
+      platform: 'twitter',
+      scheduledFor: new Date().toISOString(),
+    };
+    const res = await request(app).post('/api/posts/schedule').send(payload);
+    expect(res.status).toBe(200);
+    expect(prisma.scheduledPost.create).toHaveBeenCalled();
+    expect(postQueue.add).toHaveBeenCalled();
+    expect(emitScheduleUpdate).toHaveBeenCalled();
+    expect(res.body).toMatchObject({ userId: 1, content: 'Hello', platform: 'twitter' });
+  });
+});

--- a/backend/tests/social.test.js
+++ b/backend/tests/social.test.js
@@ -1,0 +1,46 @@
+import express from 'express';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+await jest.unstable_mockModule('axios', () => ({
+  default: { post: jest.fn() },
+}));
+
+await jest.unstable_mockModule('../src/config/db.js', () => ({
+  default: {
+    socialAccount: {
+      findFirst: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue({}),
+      update: jest.fn(),
+    },
+  },
+}));
+
+const axios = (await import('axios')).default;
+const socialRoutes = (await import('../src/routes/social.js')).default;
+const prisma = (await import('../src/config/db.js')).default;
+
+process.env.TWITTER_CLIENT_ID = 'id';
+process.env.TWITTER_CLIENT_SECRET = 'secret';
+process.env.TWITTER_REDIRECT_URI = 'https://callback';
+
+const app = express();
+app.use('/api/social', socialRoutes);
+
+describe('Social OAuth flows', () => {
+  it('generates authorization URL', async () => {
+    const res = await request(app).get('/api/social/twitter/oauth');
+    expect(res.status).toBe(200);
+    expect(res.body.url).toContain('https://twitter.com/i/oauth2/authorize');
+  });
+
+  it('handles OAuth callback', async () => {
+    axios.post.mockResolvedValue({ data: { access_token: 'a', refresh_token: 'b' } });
+    const res = await request(app)
+      .get('/api/social/twitter/callback')
+      .query({ code: 'code', userId: '1' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(prisma.socialAccount.create).toHaveBeenCalled();
+  });
+});

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     name: backend
     env: node
     rootDir: backend
-    buildCommand: npm install
+    buildCommand: npm install && npm test
     startCommand: npm start
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
## Summary
- replace placeholder backend test with suites for auth, post scheduling, and social OAuth
- mock external APIs and BullMQ/Redis components in tests
- run tests in Render build and GitHub Actions workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c20fc2ea883279d0fa7b5d6dd00bd