### PR TITLE
Secure OAuth state and use session user IDs

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,7 @@ import socialRoutes from "./src/routes/social.js";
 import postRoutes from "./src/routes/posts.js";
 import subscriptionRoutes from "./src/routes/subscriptions.js";
 import onboardingRoutes from "./src/routes/onboarding.js";
+import authMiddleware from "./src/middleware/auth.js";
 import "./src/queue/postWorker.js";
 import { initRealtime } from "./src/realtime.js";
 
@@ -30,8 +31,8 @@ app.use(express.urlencoded({ extended: false }));
 
 // API Routes
 app.use("/api/auth", authRoutes);
-app.use("/api/social", socialRoutes);
-app.use("/api/posts", postRoutes);
+app.use("/api/social", authMiddleware, socialRoutes);
+app.use("/api/posts", authMiddleware, postRoutes);
 app.use("/api/subscriptions", subscriptionRoutes);
 app.use("/api/onboarding", onboardingRoutes);
 

--- a/backend/src/config/stateStore.js
+++ b/backend/src/config/stateStore.js
@@ -1,0 +1,38 @@
+import { createClient } from 'redis';
+
+const client = createClient({ url: process.env.REDIS_URL });
+client.on('error', (err) => console.error('Redis error', err));
+client.connect().catch((err) => {
+  console.error('Redis connection failed, using in-memory store', err);
+});
+
+const memory = new Map();
+
+export async function setState(key, value, ttl = 300) {
+  if (client.isOpen) {
+    await client.set(key, value, { EX: ttl });
+  } else {
+    memory.set(key, { value, expires: Date.now() + ttl * 1000 });
+  }
+}
+
+export async function getState(key) {
+  if (client.isOpen) {
+    return await client.get(key);
+  }
+  const entry = memory.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expires) {
+    memory.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+export async function deleteState(key) {
+  if (client.isOpen) {
+    await client.del(key);
+  } else {
+    memory.delete(key);
+  }
+}

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,17 @@
+import jwt from 'jsonwebtoken';
+
+export default function auth(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = { id: payload.id };
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}

--- a/backend/src/routes/posts.js
+++ b/backend/src/routes/posts.js
@@ -8,7 +8,8 @@ const router = Router();
 
 // Schedule a post
 router.post('/schedule', async (req, res) => {
-  const { userId, content, mediaUrl, scheduledFor, platform } = req.body;
+  const { content, mediaUrl, scheduledFor, platform } = req.body;
+  const userId = req.user.id;
   try {
     const post = await prisma.scheduledPost.create({
       data: {


### PR DESCRIPTION
## Summary
- add JWT auth middleware and apply to posts and social routes
- generate and store OAuth state per user and validate on callback
- replace explicit userId params with `req.user.id`

## Testing
- `cd backend && JWT_SECRET=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c2129c5708327ae8be71be13343ed