### PR TITLE
feat: persist auth and secure post scheduling

### DIFF
--- a/frontend/pages/compose.js
+++ b/frontend/pages/compose.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const platforms = ["twitter", "facebook", "instagram"];
 
@@ -7,17 +7,34 @@ export default function Compose() {
   const [platform, setPlatform] = useState(platforms[0]);
   const [scheduledFor, setScheduledFor] = useState("");
   const [status, setStatus] = useState(null);
+  const [token, setToken] = useState(null);
+  const [userId, setUserId] = useState(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setToken(localStorage.getItem("token"));
+      setUserId(localStorage.getItem("userId"));
+    }
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
+      if (!token || !userId) {
+        setStatus("Not authenticated");
+        return;
+      }
+
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL || ""}/api/posts/schedule`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({
-            userId: 1,
+            userId,
             content,
             platform,
             scheduledFor,

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -4,6 +4,7 @@ export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [token, setToken] = useState(null);
+  const [status, setStatus] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -17,7 +18,26 @@ export default function Login() {
         }
       );
       const data = await res.json();
-      setToken(data.token || JSON.stringify(data));
+      if (data.token) {
+        // Store token for later use
+        localStorage.setItem("token", data.token);
+        setToken(data.token);
+
+        // Fetch the current user's profile to obtain the user ID
+        const meRes = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL || ""}/api/auth/me`,
+          {
+            headers: { Authorization: `Bearer ${data.token}` },
+          }
+        );
+        const meData = await meRes.json();
+        if (meData && meData.id) {
+          localStorage.setItem("userId", meData.id);
+        }
+        setStatus("Logged in");
+      } else {
+        setStatus("Login failed");
+      }
     } catch (err) {
       console.error("Login failed", err);
     }
@@ -41,9 +61,8 @@ export default function Login() {
         </div>
         <button type="submit">Login</button>
       </form>
-      {token && (
-        <pre style={{ marginTop: 20 }}>Token: {token}</pre>
-      )}
+      {token && <pre style={{ marginTop: 20 }}>Token: {token}</pre>}
+      {status && <pre style={{ marginTop: 20 }}>{status}</pre>}
     </div>
   );
 }

--- a/frontend/pages/schedule.js
+++ b/frontend/pages/schedule.js
@@ -5,11 +5,17 @@ export default function Schedule() {
   const [posts, setPosts] = useState([]);
 
   useEffect(() => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("token") : null;
+
     // Initial load
     const load = async () => {
       try {
         const res = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL || ""}/api/posts/schedule`
+          `${process.env.NEXT_PUBLIC_API_URL || ""}/api/posts/schedule`,
+          {
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
+          }
         );
         const data = await res.json();
         if (Array.isArray(data)) setPosts(data);
@@ -22,6 +28,7 @@ export default function Schedule() {
     // Socket updates
     const socket = io(process.env.NEXT_PUBLIC_API_URL || "", {
       transports: ["websocket"],
+      auth: token ? { token } : undefined,
     });
     socket.on("schedule:update", (post) => {
       setPosts((p) => [...p, post]);


### PR DESCRIPTION
## Summary
- store JWT and user id on login via `/api/auth/me`
- use stored token and user id when scheduling posts
- apply auth token to schedule fetch and socket connection

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c212ddd5c8327a1a54864b74aecbe