### PR TITLE
feat: add schedule retrieval route

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,19 @@
+import jwt from 'jsonwebtoken';
+
+// Simple JWT authentication middleware
+// Expects Authorization: Bearer <token>
+export default function auth(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = { id: decoded.id };
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+}

--- a/backend/src/routes/posts.js
+++ b/backend/src/routes/posts.js
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import prisma from '../config/db.js';
 import { postQueue } from '../queue/postWorker.js';
 import { emitScheduleUpdate } from '../realtime.js';
+import auth from '../middleware/auth.js';
 
 const router = Router();
 
@@ -28,6 +29,20 @@ router.post('/schedule', async (req, res) => {
   } catch (err) {
     console.error('Schedule post failed', err);
     res.status(500).json({ error: 'Failed to schedule post' });
+  }
+});
+
+// Retrieve scheduled posts for authenticated user
+router.get('/schedule', auth, async (req, res) => {
+  try {
+    const posts = await prisma.scheduledPost.findMany({
+      where: { userId: req.user.id },
+      orderBy: { scheduledFor: 'asc' },
+    });
+    res.json(posts);
+  } catch (err) {
+    console.error('Fetch scheduled posts failed', err);
+    res.status(500).json({ error: 'Failed to fetch scheduled posts' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add JWT auth middleware
- expose GET /schedule to list authenticated user's scheduled posts

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c212fcc80832782cc01ad81b65644