### PR TITLE
Add auth middleware and secure API routes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,7 @@ import socialRoutes from "./src/routes/social.js";
 import postRoutes from "./src/routes/posts.js";
 import subscriptionRoutes from "./src/routes/subscriptions.js";
 import onboardingRoutes from "./src/routes/onboarding.js";
+import authMiddleware from "./src/middleware/auth.js";
 import "./src/queue/postWorker.js";
 import { initRealtime } from "./src/realtime.js";
 
@@ -30,9 +31,9 @@ app.use(express.urlencoded({ extended: false }));
 
 // API Routes
 app.use("/api/auth", authRoutes);
-app.use("/api/social", socialRoutes);
-app.use("/api/posts", postRoutes);
-app.use("/api/subscriptions", subscriptionRoutes);
+app.use("/api/social", authMiddleware, socialRoutes);
+app.use("/api/posts", authMiddleware, postRoutes);
+app.use("/api/subscriptions", authMiddleware, subscriptionRoutes);
 app.use("/api/onboarding", onboardingRoutes);
 
 // Health check

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken';
+
+const authMiddleware = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded.userId || decoded.id;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};
+
+export default authMiddleware;


### PR DESCRIPTION
## Summary
- add JWT auth middleware that verifies Authorization header and sets `req.user`
- apply auth middleware to social, posts, and subscriptions routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c229c5dd08327805858c391a460f4